### PR TITLE
Build for multiple operating systems

### DIFF
--- a/build/build.ps1
+++ b/build/build.ps1
@@ -9,7 +9,7 @@ $RootDir = Join-Path $PsScriptRoot ".."
 Task PackageRestore {
   try {
     pushd $RootDir
-    exec { go get -t }
+    exec { go get -t -d }
   } finally {
     popd
   }


### PR DESCRIPTION
This is a rather trivial change (in the end) that uses the Go environment variables for OS, architecture and binary file suffix (.exe or not) to construct an appropriate output folder and filename based on the OS and architecture being built. 

The script uses whatever values are set for `GOOS` and `GOARCH`, which will default to those of the host machine but are overridden in the build configuration Powershell script to build the three different versions.

---
Connects to CloudHub360/platform#533