### PR TITLE
Write error if classifier creation fails

### DIFF
--- a/cmd/ch360/commands/createclassifier.go
+++ b/cmd/ch360/commands/createclassifier.go
@@ -35,6 +35,7 @@ func (cmd *CreateClassifier) Execute(classifierName string, samplesPath string) 
 	err := cmd.client.Create(classifierName)
 	if err != nil {
 		fmt.Println("[FAILED]")
+		fmt.Println(err.Error())
 		return err
 	}
 


### PR DESCRIPTION
If the classifier creation step failed (e.g. if there was already a classifier with the specified name) then the details of the error were not written out.

