### PR TITLE
Update API address to api.waives.io

### DIFF
--- a/ch360/apiclient.go
+++ b/ch360/apiclient.go
@@ -6,7 +6,7 @@ import (
 	"net/http"
 )
 
-const ApiAddress = "https://api.cloudhub360.com"
+const ApiAddress = "https://api.waives.io"
 
 type ApiClient struct {
 	Classifiers *ClassifiersClient


### PR DESCRIPTION
Changes the API url used to https://api.waives.io.

---
Connects to CloudHub360/platform#556