### PR TITLE
Support field aliases in extractor templates

### DIFF
--- a/ch360/extractors.go
+++ b/ch360/extractors.go
@@ -48,8 +48,14 @@ type ExtractorTemplate struct {
 }
 
 type ModuleTemplate struct {
-	ID        string                 `json:"id"`
-	Arguments map[string]interface{} `json:"arguments,omitempty"`
+	ID           string                 `json:"id"`
+	Arguments    map[string]interface{} `json:"arguments,omitempty"`
+	FieldAliases []FieldAliasTemplate   `json:"field_aliases,omitempty"`
+}
+
+type FieldAliasTemplate struct {
+	Field string `json:"field"`
+	Alias string `json:"alias"`
 }
 
 func NewModulesTemplateFromJson(stream io.Reader) (*ExtractorTemplate, error) {

--- a/ch360/extractors_test.go
+++ b/ch360/extractors_test.go
@@ -132,7 +132,7 @@ func AListOfExtractors(names ...string) ch360.ExtractorList {
 	return expected
 }
 
-const modulesTemplateJson = `{"modules":[{"id":"waives.name"},{"id":"waives.date"}]}`
+const modulesTemplateJson = `{"modules":[{"id":"waives.reference_number","arguments":{"format":"[A-Z]"},"field_aliases":[{"field":"Reference Number","alias":"Code"}]},{"id":"waives.date"}]}`
 
 func aModulesTemplate() *ch360.ExtractorTemplate {
 	template, _ := ch360.NewModulesTemplateFromJson(bytes.NewBufferString(


### PR DESCRIPTION
As a result of adding support for multiple instances of modules, extractor templates may now contain a `field_aliases` array in each module. This PR adds support for this new property.
